### PR TITLE
Set initial pose, flip field centric for red alliance, and log swervemodule distanceMeters 

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -351,11 +351,18 @@ public class Drivetrain extends SubsystemBase {
     //         : new ChassisSpeeds(xSpeedDelivered, ySpeedDelivered, rotDelivered));
     // SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, SwerveConstants.TOP_SPEED);
 
-    //Store an array of speeds for each wheel
-    //ChassisSpeeds speeds = new ChassisSpeeds(xSpeedDelivered, ySpeedDelivered, rotSpeedDelivered);
-    ChassisSpeeds speeds = fieldCentric ? 
-      ChassisSpeeds.fromFieldRelativeSpeeds(xSpeedDelivered, ySpeedDelivered, rotSpeedDelivered, getPose().getRotation()) : 
-      new ChassisSpeeds(xSpeedDelivered, ySpeedDelivered, rotSpeedDelivered);
+    //Store an array of speeds for each wheel. By default do robot centric speeds but if fieldCentric use fromFieldRelativeSpeeds
+    ChassisSpeeds speeds = new ChassisSpeeds(xSpeedDelivered, ySpeedDelivered, rotSpeedDelivered);
+    if (fieldCentric) {
+      var rotation = getPose().getRotation();
+      var allianceOptional = DriverStation.getAlliance();
+      if (allianceOptional.isPresent() && allianceOptional.get() == DriverStation.Alliance.Red) {
+        // Flip the rotation if our driverstation is red alliance so that driving is "driver centric"
+        rotation = rotation.rotateBy(Rotation2d.fromDegrees(180));
+      }
+      speeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeedDelivered, ySpeedDelivered, rotSpeedDelivered, rotation);
+
+    }
 
     //Store the states of each module
     SwerveModuleState[] swerveModuleStates = driveKinematics.toSwerveModuleStates(speeds);

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -122,11 +122,45 @@ public class Drivetrain extends SubsystemBase {
     var stateStdDevs = VecBuilder.fill(0.1, 0.1, 0.1);
     var visionStdDevs = VecBuilder.fill(1, 1, 1);
 
+    // Set our initial location and orientation based on alliance/location
+    // Location 1 is by the blue barge (either alliance)
+    // location 2 is in the middle (either alliance)
+    // location 3 is by the red barge (either alliance)
+    var initialPose = new Pose2d();
+    var locationOptional = DriverStation.getLocation();
+    var allianceOptional = DriverStation.getAlliance();
+    if (locationOptional.isPresent() && allianceOptional.isPresent()) {
+      var location = locationOptional.get();
+      var alliance = allianceOptional.get();
+      var BLUE_STARTING_LINE = 7.56;
+      var RED_STARTING_LINE = 9.99;
+      var TAG_21_Y_VALUE = 4.0259;
+      if (location== 1 && alliance== DriverStation.Alliance.Blue) {
+        initialPose = new Pose2d(BLUE_STARTING_LINE, 6.5, Rotation2d.fromDegrees(180));
+      }
+      else if (location== 2 && alliance== DriverStation.Alliance.Blue) {
+        initialPose = new Pose2d(BLUE_STARTING_LINE, TAG_21_Y_VALUE, Rotation2d.fromDegrees(180));
+      }
+      else if (location== 3 && alliance== DriverStation.Alliance.Blue) {
+        initialPose = new Pose2d(BLUE_STARTING_LINE, 1.5, Rotation2d.fromDegrees(180));
+      }
+      else if (location== 1 && alliance== DriverStation.Alliance.Red) {
+        initialPose = new Pose2d(RED_STARTING_LINE, 6.5);
+      }
+      else if (location== 2 && alliance== DriverStation.Alliance.Red) {
+        initialPose = new Pose2d(RED_STARTING_LINE, TAG_21_Y_VALUE);
+      }
+      else if (location== 3 && alliance== DriverStation.Alliance.Red) {
+        initialPose = new Pose2d(RED_STARTING_LINE, 1.5);
+      }
+    }
+
+  
     this.poseEstimator =  new SwerveDrivePoseEstimator(
       SwerveConstants.DRIVE_KINEMATICS,
       getRobotHeading(),
       getSwerveModulePos(),
-      new Pose2d(),
+      initialPose,
       stateStdDevs,
       visionStdDevs);
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -598,6 +598,7 @@ public class Drivetrain extends SubsystemBase {
     field.setRobotPose(getPose());
     SmartDashboard.putData("Odometry Field", field);
     SmartDashboard.putBoolean("fieldCentric", fieldCentric);
+    SmartDashboard.putNumber("FL distanceMeters", frontL.getPosition().distanceMeters);
   }
 
 


### PR DESCRIPTION
I have a couple of proposed changes. Feel free to take them or leave them, you're certainly not obligated to accept any of these.

Firstly I added some code to set our initial position for the pose estimator. I'm not sure if you guys have a specified order for position 1, 2, 3, but I just came up with one that I thought made sense and described it in the comments. I'm hoping that this should solve some of the pose estimation challenges we've had.

Secondly I added some code to flip field relative speeds if we're on the red alliance. I've seen team 340 (who won at Finger Lakes) do this. StuyPulse also has their code online but I haven't been able to full trace how they handle field centric controls for flipping alliances. In any case this needs to be tested to make sure it works as expected.

Lastly I added an output to the smartdashboard for the distanceMeters of the FL swerve module. I want to understand if we should be taking the negative value or if we should be inverting the drive motor. My main concern is not only about doing this cleanly, I also worry about how taking the negative value in GetSwerveModulePos will affect PathPlanner and Auto.

Again, it's at your discretion to take these or leave them. If you'd prefer to copy them in while testing so that you can evaluated them one at a time that's fine too.