### PR TITLE
Increase min distance on getNearestReefTag to guarantee a result

### DIFF
--- a/src/main/java/frc/robot/FieldConstants.java
+++ b/src/main/java/frc/robot/FieldConstants.java
@@ -236,7 +236,7 @@ public class FieldConstants {
     // Returns the nearest reef apriltag from an input pose
     public static int getNearestReefTag(Pose3d currentRobotPose) {
 
-        double minDistance = 3.0;
+        double minDistance = 30.0;
         int closestTag = -1;
 
         for(int reefTag: REEF_TAGS){


### PR DESCRIPTION
In testing today at Stuy Gabriel and I noticed that if we started driveToClosestBranch too far away from an AprilTag, the whole robot would reset. We saw on SmartDashboard that even though though the camera could see and was recognizing a tag, closestTag was -1. Going through the code I see that aprilTagFieldLayout.getTagPose returns an optional and when you try to `get` on it when it's null it throws an exception.

I think the simplest fix is to increase min_distance to 30. Unless our pose is incredibly messed up, which would be a more serious bug and would preclude any driveToClosestBranch working, this should basically guarantee that we always find a closest tag.